### PR TITLE
Fix get_author_by_id return handling

### DIFF
--- a/backend/app/services/author_services.py
+++ b/backend/app/services/author_services.py
@@ -32,8 +32,9 @@ def get_author_by_id(db: Session, id):
     """
     Returns author that match that id
     """
-
-    authors = db.query(Author).filter(Author.id == id).firt()
+    author = db.query(Author).filter(Author.id == id).first()
+    if not author:
+        return None
     return author
 
 


### PR DESCRIPTION
## Summary
- fix typo in `get_author_by_id` query
- return the found author or `None`

------
https://chatgpt.com/codex/tasks/task_e_68406f119f88832083ca8cd0b337668e