### PR TITLE
Fix database url default and missing dependency

### DIFF
--- a/backend/config/database.py
+++ b/backend/config/database.py
@@ -5,7 +5,8 @@ import os
 
 load_dotenv()
 
-DATABASE_URL = os.getenv("DATABASE_URL")
+# Use a local SQLite database if no DATABASE_URL is provided
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./dev.db")
 
 # create engine
 engine = create_engine(DATABASE_URL, echo=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ beautifulsoup4
 fanficfare
 pydantic
 pytest
+httpx


### PR DESCRIPTION
## Summary
- set default DATABASE_URL in backend
- add httpx to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6840766e9e8c832095b26463ad7fad4a