### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+starlette==0.27.0
 uvicorn
 sqlalchemy
 alembic
@@ -10,4 +11,4 @@ beautifulsoup4
 fanficfare
 pydantic
 pytest
-httpx
+httpx==0.24.1


### PR DESCRIPTION
## Summary
- pin the `httpx` version to 0.24.1 to restore compatibility with the `starlette` test client
- specify `starlette==0.27.0` in requirements

## Testing
- `PYTHONPATH=. pytest -q tests/routes/test_novel.py` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68409af9b9908320830d8e7bdab03f67