### PR TITLE
Add FanFiction.Net import support

### DIFF
--- a/README.org
+++ b/README.org
@@ -45,6 +45,13 @@ uses ~package.json~ to track both runtime and development packages for
 React, Vite and testing via Vitest. Running ~npm install~ in the
 ~frontend~ directory installs these automatically.
 
+** Supported Sources
+
+Stories can currently be imported from the following sites:
+- [[https://www.royalroad.com][RoyalRoad]]
+- [[https://forums.spacebattles.com][SpaceBattles]]
+- [[https://www.fanfiction.net][FanFiction.Net]]
+
 ** Ideas
 Like in jellyfin add a character section where all characters of the story are,
 that means parsing the chapters and collecting information

--- a/backend/app/routers/novel.py
+++ b/backend/app/routers/novel.py
@@ -25,8 +25,11 @@ router = APIRouter(
 )
 
 def supported_src(url):
-    supported = ["www.royalroad.com",
-                 "forums.spacebattles.com"]
+    supported = [
+        "www.royalroad.com",
+        "forums.spacebattles.com",
+        "www.fanfiction.net",
+    ]
     def check_url_supported(url):
         for s in supported:
             if s in url:

--- a/backend/scripts/__init__.py
+++ b/backend/scripts/__init__.py
@@ -1,0 +1,6 @@
+from .get_metadata import get_story_metadata
+from .novel_downloader import download_novel_chapter
+from .fanfiction_importer import (
+    get_fanfiction_metadata,
+    download_fanfiction_chapter,
+)

--- a/backend/scripts/fanfiction_importer.py
+++ b/backend/scripts/fanfiction_importer.py
@@ -1,0 +1,66 @@
+import os
+import cloudscraper
+from bs4 import BeautifulSoup
+from fanficfare.adapters import getAdapter
+from fanficfare.configurable import Configuration
+from fanficfare.writers import getWriter
+
+
+def get_fanfiction_metadata(url: str) -> dict:
+    """Fetch metadata for a FanFiction.Net story."""
+    scraper = cloudscraper.create_scraper()
+    resp = scraper.get(url)
+    if resp.status_code != 200:
+        raise ValueError(f"Failed to fetch url {url}: {resp.status_code}")
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    metadata: dict[str, str | int] = {}
+
+    profile = soup.find("div", id="profile_top")
+    if profile:
+        title_tag = profile.find("b", class_="xcontrast_txt")
+        if title_tag:
+            metadata["title"] = title_tag.text.strip()
+        author_tag = profile.find("a", class_="xcontrast_txt")
+        if author_tag:
+            metadata["author"] = author_tag.text.strip()
+        img_tag = profile.find("img")
+        if img_tag:
+            metadata["cover_image"] = img_tag.get("src")
+
+    select_tag = soup.find("select", id="chap_select")
+    if select_tag:
+        metadata["numChapters"] = len(select_tag.find_all("option"))
+    else:
+        metadata["numChapters"] = 1
+
+    return metadata
+
+
+def download_fanfiction_chapter(
+    url: str,
+    output_dir: str,
+    username: str,
+    library: str,
+    story_name: str,
+    format_type: str = "txt",
+    chapter_number: int = 1,
+) -> bool:
+    """Download a single chapter using FanFicFare with Cloudflare bypass."""
+    os.makedirs(output_dir, exist_ok=True)
+    story_path = os.path.join(output_dir, username, str(library), story_name)
+    os.makedirs(story_path, exist_ok=True)
+
+    config = Configuration(["defaults.ini"], "DEFAULTS")
+    if not config.has_section("overrides"):
+        config.add_section("overrides")
+    config.set("overrides", "use_cloudscraper", "true")
+
+    adapter = getAdapter(config, url)
+    adapter.setChaptersRange(chapter_number, chapter_number)
+    adapter.getStoryMetadataOnly()
+    writer = getWriter(format_type, config, adapter)
+
+    outfile = os.path.join(story_path, f"chapter_{chapter_number}.{format_type}")
+    writer.writeStory(outstream=open(outfile, "wb"))
+    return os.path.exists(outfile) and os.path.getsize(outfile) > 0

--- a/backend/scripts/get_metadata.py
+++ b/backend/scripts/get_metadata.py
@@ -2,11 +2,17 @@
 import os
 import sys
 from scripts.get_cover_image import get_royalroad_cover_image
+from .fanfiction_importer import get_fanfiction_metadata
 from fanficfare.adapters import getAdapter
 from fanficfare.configurable import Configuration
 
 
 def get_story_metadata(url):
+    """Return parsed metadata for a supported story URL."""
+    if "fanfiction.net" in url:
+        metadata = get_fanfiction_metadata(url)
+        return parse_metadata(metadata)
+
     # Create a basic configuration
     configuration = Configuration(["defaults.ini"], "DEFAULTS")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ fanficfare
 pydantic
 pytest
 httpx==0.24.1
+cloudscraper


### PR DESCRIPTION
## Summary
- support importing stories from FanFiction.Net
- add fanfiction importer utility using cloudscraper and FanFicFare
- enable FanFiction.Net URLs in novel router
- document supported sources
- include cloudscraper dependency

## Testing
- `pytest -q` *(fails: ValidationError and TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_6846abcb6bd8832082024626cb318ab7